### PR TITLE
Add BEAR.Accept annotation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ The provided `rector.php` configuration includes rules for:
 - `@Purge` → `#[Purge]`
 - `@Refresh` → `#[Refresh]`
 
+**BEAR.Accept:**
+- `@Available` → `#[Available]`
+- `@Produces` → `#[Produces]`
+
 ## See Also
 
 - [Rector - Instant PHP Upgrades](https://getrector.com/)

--- a/rector.php
+++ b/rector.php
@@ -54,4 +54,7 @@ return RectorConfig::configure()
         new AnnotationToAttribute('BEAR\Resource\Annotation\Link'),
         new AnnotationToAttribute('BEAR\Resource\Annotation\OptionsBody'),
         new AnnotationToAttribute('BEAR\Resource\Annotation\ResourceParam'),
+        // bear/accept
+        new AnnotationToAttribute('BEAR\Accept\Annotation\Available'),
+        new AnnotationToAttribute('BEAR\Accept\Annotation\Produces'),
     ]);


### PR DESCRIPTION
Add Rector rules for BEAR.Accept annotations:

- `@Available` → `#[Available]`
- `@Produces` → `#[Produces]`

Related: https://github.com/bearsunday/BEAR.Accept/pull/6

## Summary by Sourcery

Add Rector support for migrating BEAR.Accept annotations to attributes.

Enhancements:
- Register BEAR.Accept Available and Produces annotations for automatic conversion to PHP attributes.

Documentation:
- Document the new BEAR.Accept annotation-to-attribute conversions in the README.