### PR TITLE
Add injection refactoring rules and fix #1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Rector extension that provides upgrade rules for BEAR.Sunday framework, specifically for migrating from docblock annotations to PHP 8 attributes. The main rule (`RayDiNamedAnnotationRector`) converts `@Named` annotations on methods to `#[Named]` attributes on constructor parameters.
+This is a Rector extension that provides upgrade rules for BEAR.Sunday framework:
+
+1. **Annotation to Attribute migration** - Converting docblock annotations to PHP 8 attributes
+2. **Dependency Injection refactoring** - Converting setter/trait injection to constructor injection
+3. **Return type modernization** - Converting `ResourceObject` return types to `static`
 
 ## Development Commands
 
@@ -47,6 +51,15 @@ Note: When installed via `composer-bin-plugin`, the path may be:
     - `Fixture/*.php.inc` - Test fixtures (before/after pairs separated by `-----`)
     - `Fake/*.php` - Fake classes used in tests
     - `config/configured_rule.php` - Test configuration
+
+### Available Rector Rules
+
+| Rule | Purpose |
+|------|---------|
+| `RayDiNamedAnnotationRector` | `@Named("a=foo")` on method → `#[Named('foo')]` on parameters |
+| `SetterToConstructorInjectionRector` | `#[Inject]` setter → constructor injection |
+| `TraitToConstructorInjectionRector` | `use ResourceInject` → constructor injection |
+| `ResourceObjectReturnTypeRector` | `: ResourceObject` / `: self` → `: static` |
 
 ### How RayDiNamedAnnotationRector Works
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,93 @@ The provided `rector.php` configuration includes rules for:
 - `@Available` → `#[Available]`
 - `@Produces` → `#[Produces]`
 
+### SetterToConstructorInjectionRector
+
+Converts setter injection with `#[Inject]` to constructor injection.
+
+**Before:**
+```php
+class SomeClass
+{
+    private FooInterface $foo;
+
+    #[Inject]
+    public function setFoo(FooInterface $foo): void
+    {
+        $this->foo = $foo;
+    }
+}
+```
+
+**After:**
+```php
+class SomeClass
+{
+    public function __construct(
+        private readonly FooInterface $foo
+    ) {
+    }
+}
+```
+
+### TraitToConstructorInjectionRector
+
+Converts trait-based injection to constructor injection.
+
+**Supported traits:**
+- `BEAR\Resource\ResourceInject` → `ResourceInterface $resource`
+- `BEAR\Sunday\Inject\ResourceInject` → `ResourceInterface $resource`
+- `Ray\Di\InjectorInject` → `InjectorInterface $injector`
+
+**Before:**
+```php
+use BEAR\Resource\ResourceInject;
+
+class SomeClass
+{
+    use ResourceInject;
+}
+```
+
+**After:**
+```php
+use BEAR\Resource\ResourceInterface;
+
+class SomeClass
+{
+    public function __construct(
+        private readonly ResourceInterface $resource
+    ) {
+    }
+}
+```
+
+### ResourceObjectReturnTypeRector
+
+Converts `ResourceObject` and `self` return types to `static` in resource methods.
+
+**Before:**
+```php
+class Article extends ResourceObject
+{
+    public function onGet(int $id): ResourceObject
+    {
+        return $this;
+    }
+}
+```
+
+**After:**
+```php
+class Article extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+}
+```
+
 ## See Also
 
 - [Rector - Instant PHP Upgrades](https://getrector.com/)

--- a/rules-tests/RayDiNamedAnnotation/Rector/ClassMethod/RayDiNamedAnnotationRector/Fixture/single_param.php.inc
+++ b/rules-tests/RayDiNamedAnnotation/Rector/ClassMethod/RayDiNamedAnnotationRector/Fixture/single_param.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\RayDiNamedAnnotation\Rector\ClassMethod\RayDiNamedAnnotationRector\Fixture;
+
+use Ray\Di\Di\Named;
+
+class SingleParamClass
+{
+    /**
+     * @Named("foo")
+     */
+    public function __construct(int $a)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\RayDiNamedAnnotation\Rector\ClassMethod\RayDiNamedAnnotationRector\Fixture;
+
+use Ray\Di\Di\Named;
+
+class SingleParamClass
+{
+    public function __construct(#[\Ray\Di\Di\Named('foo')]
+    int $a)
+    {
+    }
+}
+
+?>

--- a/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/resource_object_return.php.inc
+++ b/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/resource_object_return.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector\Fixture;
+
+use BEAR\Resource\ResourceObject;
+
+class Article extends ResourceObject
+{
+    public function onGet(int $id): ResourceObject
+    {
+        return $this;
+    }
+
+    public function onPost(string $title): ResourceObject
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector\Fixture;
+
+use BEAR\Resource\ResourceObject;
+
+class Article extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+
+    public function onPost(string $title): static
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/self_return.php.inc
+++ b/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/self_return.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector\Fixture;
+
+use BEAR\Resource\ResourceObject;
+
+class User extends ResourceObject
+{
+    public function onGet(int $id): self
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector\Fixture;
+
+use BEAR\Resource\ResourceObject;
+
+class User extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/skip_already_static.php.inc
+++ b/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/skip_already_static.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector\Fixture;
+
+use BEAR\Resource\ResourceObject;
+
+class SkipAlreadyStaticClass extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/skip_non_resource_class.php.inc
+++ b/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/Fixture/skip_non_resource_class.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector\Fixture;
+
+class SkipNonResourceClass
+{
+    public function onGet(int $id): self
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/ResourceObjectReturnTypeRectorTest.php
+++ b/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/ResourceObjectReturnTypeRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ResourceObjectReturnTypeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<string>
+     */
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/config/configured_rule.php
+++ b/rules-tests/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\BearSunday\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        ResourceObjectReturnTypeRector::class,
+    ]);

--- a/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/existing_constructor.php.inc
+++ b/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/existing_constructor.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\Fixture;
+
+use Ray\Di\Di\Inject;
+
+interface FooInterface {}
+interface BarInterface {}
+
+class ExistingConstructorClass
+{
+    private FooInterface $foo;
+
+    public function __construct(
+        private readonly BarInterface $bar
+    ) {
+    }
+
+    #[Inject]
+    public function setFoo(FooInterface $foo): void
+    {
+        $this->foo = $foo;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\Fixture;
+
+use Ray\Di\Di\Inject;
+
+interface FooInterface {}
+interface BarInterface {}
+
+class ExistingConstructorClass
+{
+    public function __construct(
+        private readonly BarInterface $bar, private readonly FooInterface $foo
+    ) {
+    }
+}
+
+?>

--- a/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/multiple_setters.php.inc
+++ b/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/multiple_setters.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\Fixture;
+
+use Ray\Di\Di\Inject;
+
+interface FooInterface {}
+interface BarInterface {}
+
+class MultipleSettersClass
+{
+    private FooInterface $foo;
+    private BarInterface $bar;
+
+    #[Inject]
+    public function setFoo(FooInterface $foo): void
+    {
+        $this->foo = $foo;
+    }
+
+    #[Inject]
+    public function setBar(BarInterface $bar): void
+    {
+        $this->bar = $bar;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\Fixture;
+
+use Ray\Di\Di\Inject;
+
+interface FooInterface {}
+interface BarInterface {}
+
+class MultipleSettersClass
+{
+    public function __construct(private readonly FooInterface $foo, private readonly BarInterface $bar)
+    {
+    }
+}
+
+?>

--- a/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/simple_setter.php.inc
+++ b/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/simple_setter.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\Fixture;
+
+use Ray\Di\Di\Inject;
+
+interface FooInterface {}
+
+class SimpleSetterClass
+{
+    private FooInterface $foo;
+
+    #[Inject]
+    public function setFoo(FooInterface $foo): void
+    {
+        $this->foo = $foo;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\Fixture;
+
+use Ray\Di\Di\Inject;
+
+interface FooInterface {}
+
+class SimpleSetterClass
+{
+    public function __construct(private readonly FooInterface $foo)
+    {
+    }
+}
+
+?>

--- a/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/skip_non_inject_setter.php.inc
+++ b/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/Fixture/skip_non_inject_setter.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\Fixture;
+
+interface FooInterface {}
+
+class SkipNonInjectSetterClass
+{
+    private FooInterface $foo;
+
+    public function setFoo(FooInterface $foo): void
+    {
+        $this->foo = $foo;
+    }
+}
+
+?>

--- a/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/SetterToConstructorInjectionRectorTest.php
+++ b/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/SetterToConstructorInjectionRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SetterToConstructorInjectionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<string>
+     */
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/config/configured_rule.php
+++ b/rules-tests/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\BearSunday\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        SetterToConstructorInjectionRector::class,
+    ]);

--- a/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/existing_constructor.php.inc
+++ b/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/existing_constructor.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\Fixture;
+
+use BEAR\Resource\ResourceInject;
+
+interface FooInterface {}
+
+class ExistingConstructorClass
+{
+    use ResourceInject;
+
+    public function __construct(
+        private readonly FooInterface $foo
+    ) {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\Fixture;
+
+use BEAR\Resource\ResourceInject;
+
+interface FooInterface {}
+
+class ExistingConstructorClass
+{
+    public function __construct(
+        private readonly FooInterface $foo, private readonly \BEAR\Resource\ResourceInterface $resource
+    ) {
+    }
+}
+
+?>

--- a/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/existing_constructor.php.inc
+++ b/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/existing_constructor.php.inc
@@ -22,8 +22,6 @@ class ExistingConstructorClass
 
 namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\Fixture;
 
-use BEAR\Resource\ResourceInject;
-
 interface FooInterface {}
 
 class ExistingConstructorClass

--- a/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/resource_inject.php.inc
+++ b/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/resource_inject.php.inc
@@ -20,8 +20,6 @@ class ResourceInjectClass
 
 namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\Fixture;
 
-use BEAR\Resource\ResourceInject;
-
 class ResourceInjectClass
 {
     public function __construct(private readonly \BEAR\Resource\ResourceInterface $resource)

--- a/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/resource_inject.php.inc
+++ b/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/resource_inject.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\Fixture;
+
+use BEAR\Resource\ResourceInject;
+
+class ResourceInjectClass
+{
+    use ResourceInject;
+
+    public function doSomething(): void
+    {
+        $this->resource->get('app://self/user');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\Fixture;
+
+use BEAR\Resource\ResourceInject;
+
+class ResourceInjectClass
+{
+    public function __construct(private readonly \BEAR\Resource\ResourceInterface $resource)
+    {
+    }
+
+    public function doSomething(): void
+    {
+        $this->resource->get('app://self/user');
+    }
+}
+
+?>

--- a/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/skip_non_matching_trait.php.inc
+++ b/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/Fixture/skip_non_matching_trait.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\Fixture;
+
+trait SomeOtherTrait
+{
+    public function someMethod(): void
+    {
+    }
+}
+
+class SkipNonMatchingTraitClass
+{
+    use SomeOtherTrait;
+}
+
+?>

--- a/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/TraitToConstructorInjectionRectorTest.php
+++ b/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/TraitToConstructorInjectionRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TraitToConstructorInjectionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<string>
+     */
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/config/configured_rule.php
+++ b/rules-tests/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\BearSunday\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        TraitToConstructorInjectionRector::class,
+    ]);

--- a/rules/RayDiNamedAnnotation/Rector/ClassMethod/RayDiNamedAnnotationRector.php
+++ b/rules/RayDiNamedAnnotation/Rector/ClassMethod/RayDiNamedAnnotationRector.php
@@ -93,14 +93,22 @@ CODE_SAMPLE
         $names = $this->parseName($nameString);
         $hasChanged = false;
 
-        foreach ($node->params as $param) {
-            $varName = $param->var->name;
-            if (! isset($names[$varName])) {
-                continue;
-            }
-            $attrGroupsFromNamedAnnotation = $this->attributeGroupFactory->createFromClassWithItems(Named::class, [$names[$varName]]);
+        // Handle single parameter case: @Named("foo") without key=value format
+        if ($names === [] && count($node->params) === 1) {
+            $param = $node->params[0];
+            $attrGroupsFromNamedAnnotation = $this->attributeGroupFactory->createFromClassWithItems(Named::class, [trim($nameString)]);
             $param->attrGroups = array_merge($param->attrGroups, [$attrGroupsFromNamedAnnotation]);
             $hasChanged = true;
+        } else {
+            foreach ($node->params as $param) {
+                $varName = $param->var->name;
+                if (! isset($names[$varName])) {
+                    continue;
+                }
+                $attrGroupsFromNamedAnnotation = $this->attributeGroupFactory->createFromClassWithItems(Named::class, [$names[$varName]]);
+                $param->attrGroups = array_merge($param->attrGroups, [$attrGroupsFromNamedAnnotation]);
+                $hasChanged = true;
+            }
         }
 
         if (! $hasChanged) {

--- a/rules/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector.php
+++ b/rules/ResourceObject/Rector/ClassMethod/ResourceObjectReturnTypeRector.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\BearSunday\ResourceObject\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+use function assert;
+use function in_array;
+use function str_starts_with;
+
+/**
+ * Converts ResourceObject return type to static in resource methods
+ *
+ * @see \Rector\Tests\ResourceObject\Rector\ClassMethod\ResourceObjectReturnTypeRector\ResourceObjectReturnTypeRectorTest
+ */
+final class ResourceObjectReturnTypeRector extends AbstractRector
+{
+    private const RESOURCE_METHODS = ['onGet', 'onPost', 'onPut', 'onPatch', 'onDelete'];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Convert ResourceObject return type to static in resource methods', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use BEAR\Resource\ResourceObject;
+
+class Article extends ResourceObject
+{
+    public function onGet(int $id): ResourceObject
+    {
+        return $this;
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use BEAR\Resource\ResourceObject;
+
+class Article extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Class_);
+
+        if (! $this->isResourceObjectClass($node)) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->getMethods() as $method) {
+            if (! $this->isResourceMethod($method)) {
+                continue;
+            }
+
+            if ($this->shouldChangeReturnType($method)) {
+                $method->returnType = new Identifier('static');
+                $hasChanged = true;
+            }
+        }
+
+        return $hasChanged ? $node : null;
+    }
+
+    private function isResourceObjectClass(Class_ $class): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $parentClassName = $class->extends->toString();
+
+        return $parentClassName === 'ResourceObject'
+            || $parentClassName === 'BEAR\Resource\ResourceObject';
+    }
+
+    private function isResourceMethod(ClassMethod $method): bool
+    {
+        $methodName = $method->name->toString();
+
+        return in_array($methodName, self::RESOURCE_METHODS, true);
+    }
+
+    private function shouldChangeReturnType(ClassMethod $method): bool
+    {
+        $returnType = $method->returnType;
+
+        if ($returnType === null) {
+            return false;
+        }
+
+        // Get string representation of return type
+        $typeName = '';
+        if ($returnType instanceof Name) {
+            $typeName = $returnType->toString();
+        } elseif ($returnType instanceof Identifier) {
+            $typeName = $returnType->name;
+        }
+
+        // Already static - no change needed
+        if ($typeName === 'static') {
+            return false;
+        }
+
+        // Should change: ResourceObject, self, or fully qualified ResourceObject
+        return $typeName === 'ResourceObject'
+            || $typeName === 'BEAR\Resource\ResourceObject'
+            || $typeName === 'self';
+    }
+}

--- a/rules/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector.php
+++ b/rules/SetterInjection/Rector/Class_/SetterToConstructorInjectionRector.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\BearSunday\SetterInjection\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use Ray\Di\Di\Inject;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+use function array_filter;
+use function array_values;
+use function assert;
+use function count;
+use function lcfirst;
+use function str_starts_with;
+use function substr;
+
+/**
+ * Converts setter injection with #[Inject] to constructor injection
+ *
+ * @see \Rector\Tests\SetterInjection\Rector\Class_\SetterToConstructorInjectionRector\SetterToConstructorInjectionRectorTest
+ */
+final class SetterToConstructorInjectionRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Convert setter injection with #[Inject] to constructor injection', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    private FooInterface $foo;
+
+    #[Inject]
+    public function setFoo(FooInterface $foo): void
+    {
+        $this->foo = $foo;
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __construct(
+        private readonly FooInterface $foo
+    ) {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Class_);
+
+        $injectSetters = $this->findInjectSetters($node);
+        if ($injectSetters === []) {
+            return null;
+        }
+
+        $propertiesToRemove = [];
+        $newConstructorParams = [];
+
+        foreach ($injectSetters as $setter) {
+            $setterInfo = $this->extractSetterInfo($setter);
+            if ($setterInfo === null) {
+                continue;
+            }
+
+            [$paramType, $paramName, $propertyName] = $setterInfo;
+
+            // Create constructor parameter with promoted property
+            $param = new Param(
+                new Variable($paramName),
+                null,
+                $paramType,
+                false,
+                false,
+                [],
+                Class_::MODIFIER_PRIVATE | Class_::MODIFIER_READONLY
+            );
+
+            $newConstructorParams[] = $param;
+            $propertiesToRemove[] = $propertyName;
+        }
+
+        if ($newConstructorParams === []) {
+            return null;
+        }
+
+        // Find or create constructor
+        $constructor = $node->getMethod('__construct');
+        if ($constructor === null) {
+            $constructor = new ClassMethod(new Identifier('__construct'));
+            $constructor->flags = Class_::MODIFIER_PUBLIC;
+            $constructor->params = [];
+            $constructor->stmts = [];
+
+            // Add constructor at the beginning of the class
+            array_unshift($node->stmts, $constructor);
+        }
+
+        // Add new parameters to constructor
+        $constructor->params = array_merge($constructor->params, $newConstructorParams);
+
+        // Remove setter methods and related properties
+        $node->stmts = array_values(array_filter($node->stmts, function ($stmt) use ($injectSetters, $propertiesToRemove) {
+            // Remove setter methods
+            if ($stmt instanceof ClassMethod) {
+                foreach ($injectSetters as $setter) {
+                    if ($stmt === $setter) {
+                        return false;
+                    }
+                }
+            }
+
+            // Remove properties that were converted
+            if ($stmt instanceof Property) {
+                foreach ($stmt->props as $prop) {
+                    if (in_array($prop->name->toString(), $propertiesToRemove, true)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }));
+
+        return $node;
+    }
+
+    /**
+     * @return ClassMethod[]
+     */
+    private function findInjectSetters(Class_ $class): array
+    {
+        $setters = [];
+
+        foreach ($class->getMethods() as $method) {
+            if (! str_starts_with($method->name->toString(), 'set')) {
+                continue;
+            }
+
+            foreach ($method->attrGroups as $attrGroup) {
+                foreach ($attrGroup->attrs as $attr) {
+                    $attrName = $attr->name->toString();
+                    if ($attrName === 'Inject' || $attrName === 'Ray\Di\Di\Inject') {
+                        $setters[] = $method;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        return $setters;
+    }
+
+    /**
+     * @return array{Node\Name|Node\Identifier|Node\ComplexType|null, string, string}|null
+     */
+    private function extractSetterInfo(ClassMethod $method): ?array
+    {
+        if (count($method->params) !== 1) {
+            return null;
+        }
+
+        $param = $method->params[0];
+        $paramType = $param->type;
+        $paramName = $param->var->name;
+
+        // Try to find property name from assignment in method body
+        $propertyName = $paramName;
+        if ($method->stmts !== null) {
+            foreach ($method->stmts as $stmt) {
+                if ($stmt instanceof Node\Stmt\Expression && $stmt->expr instanceof Assign) {
+                    $assign = $stmt->expr;
+                    if ($assign->var instanceof PropertyFetch && $assign->var->var instanceof Variable) {
+                        if ($assign->var->var->name === 'this' && $assign->var->name instanceof Identifier) {
+                            $propertyName = $assign->var->name->toString();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return [$paramType, $paramName, $propertyName];
+    }
+}

--- a/rules/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector.php
+++ b/rules/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\BearSunday\TraitInjection\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\TraitUse;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+use function array_filter;
+use function array_merge;
+use function array_unshift;
+use function array_values;
+use function assert;
+
+/**
+ * Converts trait-based injection to constructor injection
+ *
+ * @see \Rector\Tests\TraitInjection\Rector\Class_\TraitToConstructorInjectionRector\TraitToConstructorInjectionRectorTest
+ */
+final class TraitToConstructorInjectionRector extends AbstractRector
+{
+    /**
+     * Mapping of trait names to [interface, property name]
+     * @var array<string, array{0: string, 1: string}>
+     */
+    private const TRAIT_TO_INJECTION = [
+        'BEAR\Resource\ResourceInject' => ['BEAR\Resource\ResourceInterface', 'resource'],
+        'BEAR\Sunday\Inject\ResourceInject' => ['BEAR\Resource\ResourceInterface', 'resource'],
+        'Ray\Di\InjectorInject' => ['Ray\Di\InjectorInterface', 'injector'],
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Convert trait-based injection to constructor injection', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use BEAR\Resource\ResourceInject;
+
+class SomeClass
+{
+    use ResourceInject;
+
+    public function doSomething(): void
+    {
+        $this->resource->get('app://self/user');
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use BEAR\Resource\ResourceInterface;
+
+class SomeClass
+{
+    public function __construct(
+        private readonly ResourceInterface $resource
+    ) {
+    }
+
+    public function doSomething(): void
+    {
+        $this->resource->get('app://self/user');
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Class_);
+
+        $traitsToRemove = [];
+        $newConstructorParams = [];
+
+        foreach ($node->stmts as $stmt) {
+            if (! $stmt instanceof TraitUse) {
+                continue;
+            }
+
+            foreach ($stmt->traits as $trait) {
+                $traitName = $trait->toString();
+
+                foreach (self::TRAIT_TO_INJECTION as $knownTrait => $injection) {
+                    if ($this->matchesTraitName($traitName, $knownTrait)) {
+                        [$interfaceName, $propertyName] = $injection;
+
+                        $param = new Param(
+                            new Variable($propertyName),
+                            null,
+                            new FullyQualified($interfaceName),
+                            false,
+                            false,
+                            [],
+                            Class_::MODIFIER_PRIVATE | Class_::MODIFIER_READONLY
+                        );
+
+                        $newConstructorParams[] = $param;
+                        $traitsToRemove[] = $traitName;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if ($newConstructorParams === []) {
+            return null;
+        }
+
+        // Find or create constructor
+        $constructor = $node->getMethod('__construct');
+        if ($constructor === null) {
+            $constructor = new ClassMethod(new Identifier('__construct'));
+            $constructor->flags = Class_::MODIFIER_PUBLIC;
+            $constructor->params = [];
+            $constructor->stmts = [];
+
+            // Find the position after trait uses to insert constructor
+            $insertPosition = 0;
+            foreach ($node->stmts as $index => $stmt) {
+                if ($stmt instanceof TraitUse) {
+                    $insertPosition = $index + 1;
+                }
+            }
+
+            array_splice($node->stmts, $insertPosition, 0, [$constructor]);
+        }
+
+        // Add new parameters to constructor (at the end)
+        $constructor->params = array_merge($constructor->params, $newConstructorParams);
+
+        // Remove trait uses
+        $node->stmts = array_values(array_filter($node->stmts, function ($stmt) use ($traitsToRemove) {
+            if (! $stmt instanceof TraitUse) {
+                return true;
+            }
+
+            // Filter out matching traits
+            $remainingTraits = array_filter($stmt->traits, function ($trait) use ($traitsToRemove) {
+                $traitName = $trait->toString();
+                foreach ($traitsToRemove as $toRemove) {
+                    if ($this->matchesTraitName($traitName, $toRemove)) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+
+            // If no traits remain, remove the entire statement
+            if ($remainingTraits === []) {
+                return false;
+            }
+
+            // Update with remaining traits
+            $stmt->traits = array_values($remainingTraits);
+            return true;
+        }));
+
+        return $node;
+    }
+
+    private function matchesTraitName(string $usedTrait, string $knownTrait): bool
+    {
+        // Exact match
+        if ($usedTrait === $knownTrait) {
+            return true;
+        }
+
+        // Match short name (e.g., "ResourceInject" matches "BEAR\Resource\ResourceInject")
+        $shortName = substr($knownTrait, strrpos($knownTrait, '\\') + 1);
+        return $usedTrait === $shortName;
+    }
+}

--- a/rules/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector.php
+++ b/rules/TraitInjection/Rector/Class_/TraitToConstructorInjectionRector.php
@@ -12,13 +12,14 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 use function array_filter;
 use function array_merge;
-use function array_unshift;
 use function array_values;
 use function assert;
 
@@ -82,14 +83,19 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Class_::class];
+        return [Class_::class, Use_::class];
     }
 
     /**
-     * @param Class_ $node
+     * @param Class_|Use_ $node
+     * @return Node|Node[]|int|null
      */
-    public function refactor(Node $node): ?Node
+    public function refactor(Node $node): Node|array|int|null
     {
+        if ($node instanceof Use_) {
+            return $this->refactorUse($node);
+        }
+
         assert($node instanceof Class_);
 
         $traitsToRemove = [];
@@ -191,5 +197,17 @@ CODE_SAMPLE
         // Match short name (e.g., "ResourceInject" matches "BEAR\Resource\ResourceInject")
         $shortName = substr($knownTrait, strrpos($knownTrait, '\\') + 1);
         return $usedTrait === $shortName;
+    }
+
+    private function refactorUse(Use_ $node): int|null
+    {
+        foreach ($node->uses as $useUse) {
+            $useName = $useUse->name->toString();
+            if (isset(self::TRAIT_TO_INJECTION[$useName])) {
+                return NodeVisitor::REMOVE_NODE;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

Add three new Rector rules for BEAR.Sunday code modernization and fix issue #1.

### New Rules

- **SetterToConstructorInjectionRector**: Convert `#[Inject]` setter methods to constructor injection
- **TraitToConstructorInjectionRector**: Convert `ResourceInject` and similar traits to constructor injection
- **ResourceObjectReturnTypeRector**: Convert `ResourceObject`/`self` return types to `static`

### Bug Fix

- **Fix #1**: Handle single parameter `@Named("foo")` without key=value format

## Examples

### SetterToConstructorInjectionRector

```php
// Before
#[Inject]
public function setFoo(FooInterface $foo): void

// After
public function __construct(private readonly FooInterface $foo)
```

### TraitToConstructorInjectionRector

```php
// Before
use ResourceInject;

// After
public function __construct(private readonly ResourceInterface $resource)
```

### ResourceObjectReturnTypeRector

```php
// Before
public function onGet(int $id): ResourceObject

// After
public function onGet(int $id): static
```

### Fix #1: Single parameter Named

```php
// Before
/**
 * @Named("foo")
 */
public function __construct(int $a)

// After
public function __construct(#[Named('foo')] int $a)
```

## Test plan

- [x] All existing tests pass
- [x] New tests added for each rule
- [x] Test added for single parameter @Named fix